### PR TITLE
Fixed cdnURL bug in config when loading on initialization

### DIFF
--- a/src/ngx-segment-analytics.service.ts
+++ b/src/ngx-segment-analytics.service.ts
@@ -50,14 +50,16 @@ export class SegmentService {
         }
 
         if (this._config.loadOnInitialization && !SegmentService._segmentInstance.instance?.initialized) {
+            let cdnURL: string | undefined;
+            
             if (this._config.segmentHost) {
                 // Deprecated option
-                const cdnUrl = 'https://' + this._config.segmentHost;
+                cdnURL = 'https://' + this._config.segmentHost;
             } else {
-                const cdnUrl = this._config.cdnURL;
+                cdnURL = this._config.cdnURL;
             }
 
-            this.load({writeKey: this._config.apiKey, cdnURL: this._config.segmentHost});
+            this.load({writeKey: this._config.apiKey, cdnURL});
         }
     }
 

--- a/src/ngx-segment-analytics.service.ts
+++ b/src/ngx-segment-analytics.service.ts
@@ -50,16 +50,16 @@ export class SegmentService {
         }
 
         if (this._config.loadOnInitialization && !SegmentService._segmentInstance.instance?.initialized) {
-            let cdnURL: string | undefined;
+            let cdnUrl: string | undefined;
             
             if (this._config.segmentHost) {
                 // Deprecated option
-                cdnURL = 'https://' + this._config.segmentHost;
+                cdnUrl = 'https://' + this._config.segmentHost;
             } else {
-                cdnURL = this._config.cdnURL;
+                cdnUrl = this._config.cdnURL;
             }
 
-            this.load({writeKey: this._config.apiKey, cdnURL});
+            this.load({writeKey: this._config.apiKey, cdnURL: cdnUrl});
         }
     }
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **canary branch** (left side). Also you should start *your branch* off *our canary*.
    > I don't see the **canary branch**, there's only `master`
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Description

This PR fixes a bug described here: #192.

When loading Segment on initialization, the `cdnURL` link is constructed but then ignored and defaults back to `segmentHost` (which is a deprecated field). In Angular 18, this is causing the Segment CDN URL to be missing the protocol and becoming an absolute URL using Angular's host, therefore Segment initialization fails.